### PR TITLE
Set permissions on run.sh in Dockerfile

### DIFF
--- a/mysgw/Dockerfile
+++ b/mysgw/Dockerfile
@@ -38,4 +38,5 @@ LABEL \
     org.label-schema.vcs-url="https://github.com/ghiglie/hassio-addons/addon-mysgw" \
     org.label-schema.vendor="Marco Ghiglieri Hass.io Add-ons"
 
+RUN chmod a+x /run.sh
 CMD [ "/run.sh" ]


### PR DESCRIPTION
Should fix this error when starting addon:

ifelse: fatal: unable to exec /run.sh: Permission denied
[cmd] /run.sh exited 111